### PR TITLE
Adjust left overlay meta contrast

### DIFF
--- a/css/ui.css
+++ b/css/ui.css
@@ -168,7 +168,8 @@ body {
 #text_overlay_container_left .left-meta .char {
     background: transparent;
     color: inherit;
-    mix-blend-mode: inherit;
+    line-height: 0.9;
+    mix-blend-mode: difference;
 }
 
 #text_overlay_container_left .left-meta a {

--- a/css/ui.css
+++ b/css/ui.css
@@ -99,8 +99,8 @@ body {
 }
 
 /* Left overlay: apply white background to name and bio tokens (match right overlay readability) */
-#text_overlay_container_left .word,
-#text_overlay_container_left .space {
+#text_overlay_container_left .word:not(.left-meta-token),
+#text_overlay_container_left .space:not(.left-meta-gap) {
     background: #ffffff;
     color: #000;
     mix-blend-mode: normal;
@@ -155,6 +155,8 @@ body {
     pointer-events: auto;
     -webkit-text-stroke: 0;
     text-shadow: none;
+    display: inline-block;
+    isolation: isolate;
 }
 
 /* Ensure difference blending on the meta block and its descendants (no white background) */
@@ -163,9 +165,8 @@ body {
     mix-blend-mode: difference;
 }
 
-#text_overlay_container_left .left-meta .word,
-#text_overlay_container_left .left-meta .space,
-#text_overlay_container_left .left-meta .char {
+#text_overlay_container_left .left-meta .left-meta-token,
+#text_overlay_container_left .left-meta .left-meta-gap {
     background: transparent;
     color: inherit;
     line-height: 0.9;

--- a/js/dynamicTextOverlay.js
+++ b/js/dynamicTextOverlay.js
@@ -52,13 +52,16 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 
     // Simple word/space wrapper (no highlight), matching right overlay tokenization
-    const wrapWords = (text) => {
+    const wrapWords = (text, classes = {}) => {
+      const opts = typeof classes === 'object' && classes !== null ? classes : {};
+      const extraWordClass = opts.word ? ` ${opts.word}` : '';
+      const extraSpaceClass = opts.space ? ` ${opts.space}` : '';
       const parts = String(text).split(/(\s+)/);
       return parts
         .map((part, i) => {
-          if (i % 2 === 1) return `<span class="space">${part}</span>`;
+          if (i % 2 === 1) return `<span class="space${extraSpaceClass}">${part}</span>`;
           if (!part) return "";
-          return `<span class="word">${part}</span>`;
+          return `<span class="word${extraWordClass}">${part}</span>`;
         })
         .join("");
     };
@@ -98,6 +101,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const emailHTML = `<span class="word contact-chip" role="link" tabindex="0" data-no-custom-cursor="true" data-url="mailto:paulpaturel75@gmail.com">paulpaturel75@gmail.com</span>`;
       const instaHTML = `<span class="word contact-chip" role="link" tabindex="0" data-no-custom-cursor="true" data-url="https://www.instagram.com/_paul_pat_/">@_paul_pat_</span>`;
       const copy = bioCopy[currentLang] || bioCopy.en;
+      const metaClasses = { word: 'left-meta-token', space: 'left-meta-gap' };
       const html = [
         // Next line after name
         "<br>",
@@ -125,15 +129,15 @@ document.addEventListener("DOMContentLoaded", () => {
         "<br>",
         '<span class="left-meta">',
           // Line 1: version
-          wrapWords('V0.0 released 16/09/2025.'),
+          wrapWords('V0.0 released 16/09/2025.', metaClasses),
           '<br>',
           // Line 2: font credit
-          wrapWords('Font → Arzier by '),
+          wrapWords('Font → Arzier by ', metaClasses),
           // Linked author token
-          '<span class="word contact-chip" role="link" tabindex="0" data-no-custom-cursor="true" data-url="https://hugoscholl.ch/">Hugo Scholl</span>',
-          '<span class="space"> </span>',
+          '<span class="word left-meta-token contact-chip" role="link" tabindex="0" data-no-custom-cursor="true" data-url="https://hugoscholl.ch/">Hugo Scholl</span>',
+          '<span class="space left-meta-gap"> </span>',
           // "- Interscript." as tokenized words
-          wrapWords('- Interscript.'),
+          wrapWords('- Interscript.', metaClasses),
         '</span>',
       ].join("");
       bioEl.innerHTML = html;


### PR DESCRIPTION
## Summary
- enforce the version meta text to render with a difference blend mode for better contrast on imagery
- keep the metadata words white and explicitly apply the compact 0.9 line height to each token

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c99d2fc6b083269e60af3d94eb599c